### PR TITLE
fix(dhcp): add missing ip and tftpip params to modal requests

### DIFF
--- a/templates/pages/dhcp.templ
+++ b/templates/pages/dhcp.templ
@@ -56,10 +56,10 @@
                             </button>
                         </td>
                         <td class="text-center">
-                            <button hx-get="/open_modal?template=bootmodal&network={{$tftpip}}&mac={{.MAC}}" hx-target="#modal-content" hx-swap="innerHTML" id="bootMenuBtn-{{ .MAC }}" class="btn btn-xs {{if .Menu.Filename}}btn-accent{{else}}btn-ghost{{end}}">Configure</button>
+                            <button hx-get="/open_modal?template=bootmodal&tftpip={{$tftpip}}&mac={{.MAC}}&ip={{.IP}}" hx-target="#modal-content" hx-swap="innerHTML" id="bootMenuBtn-{{ .MAC }}" class="btn btn-xs {{if .Menu.Filename}}btn-accent{{else}}btn-ghost{{end}}">Configure</button>
                         </td>
                         <td class="text-center">
-                            <button hx-get="/open_modal?template=ipmimodal&network={{$tftpip}}&mac={{.MAC}}" hx-target="#modal-content" hx-swap="innerHTML" id="ipmiBtn-{{ .MAC }}" class="btn btn-xs {{if .IPMI.Username}}btn-accent{{else}}btn-ghost{{end}}">Configure</button>
+                            <button hx-get="/open_modal?template=ipmimodal&tftpip={{$tftpip}}&mac={{.MAC}}&ip={{.IP}}" hx-target="#modal-content" hx-swap="innerHTML" id="ipmiBtn-{{ .MAC }}" class="btn btn-xs {{if .IPMI.Username}}btn-accent{{else}}btn-ghost{{end}}">Configure</button>
                         </td>
                     </tr>
                     {{end}}


### PR DESCRIPTION
The bootmenu and ipmimenu modals were failing to open due to missing query parameters in the hx-get requests. The backend was expecting `ip` and `tftpip` parameters, but the frontend was not sending the `ip` and was sending `network` instead of `tftpip`.

This commit updates the `dhcp.templ` template to include the `ip` parameter and use the `tftpip` parameter name in the requests to open the boot and IPMI modals.