### PR TITLE
refactor: Optimize DHCP lease management

### DIFF
--- a/internal/handlers/bootmenu.go
+++ b/internal/handlers/bootmenu.go
@@ -160,12 +160,13 @@ func updateDHCPLease(tftpip, mac string, menu dhcp.BootMenu) error {
 		return fmt.Errorf("unable to get DHCP server: %w", err)
 	}
 
-	for i, lease := range dhcpHandler.Leases {
-		if lease.MAC == mac {
-			lease.Menu = menu
-			dhcpHandler.Leases[i] = lease
-			return dhcpHandler.UpdateDBState()
-		}
+	lease, ok := dhcpHandler.Leases[mac]
+	if !ok {
+		return fmt.Errorf("lease not found for MAC %s", mac)
 	}
-	return fmt.Errorf("lease not found for MAC %s", mac)
+
+	lease.Menu = menu
+	dhcpHandler.Leases[mac] = lease
+
+	return dhcpHandler.UpdateDBState()
 }

--- a/internal/handlers/ipmi.go
+++ b/internal/handlers/ipmi.go
@@ -45,12 +45,11 @@ func (h *Handlers) SubmitIPMI(w http.ResponseWriter, r *http.Request) {
 
 	// Update lease in DHCP handler
 	if lease, ok := dhcpHandler.Leases[mac]; ok {
-		lease.IPMI = dhcp.IPMI{
-			Pxeboot:  bootConfigChecked,
-			Reboot:   rebootChecked,
-			IP:       net.ParseIP(ip),
-			Username: username,
-		}
+		lease.IPMI.Pxeboot = bootConfigChecked
+		lease.IPMI.Reboot = rebootChecked
+		lease.IPMI.IP = net.ParseIP(ip)
+		lease.IPMI.Username = username
+
 		dhcpHandler.Leases[mac] = lease
 		if err := dhcpHandler.UpdateDBState(); err != nil {
 			errors.HandleHTTPError(w, h.Logger, errors.NewDatabaseError("update_lease", err))


### PR DESCRIPTION
This commit refactors the DHCP lease management to be more efficient and correct.

The previous implementation used inefficient loops to look up leases by MAC address in the `DHCPHandler.Leases` map. This has been replaced with direct map lookups using the MAC address as the key.

The following functions have been updated:
- `dhcp.findPreviousLease`
- `dhcp.removeLeaseByMAC`
- `dhcp.SetLeaseReservation`
- `handlers.updateDHCPLease`

In addition, the logic in `handlers.SubmitIPMI` has been slightly improved to modify the existing `IPMI` struct rather than overwriting it.

These changes fix a bug where DHCP, IPMI, and boot handler data was not being correctly persisted to the database, and improves the overall quality and performance of the code.